### PR TITLE
Allow "text/plain" content type for error pages

### DIFF
--- a/src/main/java/act/util/ActErrorPageRender.java
+++ b/src/main/java/act/util/ActErrorPageRender.java
@@ -116,6 +116,7 @@ public class ActErrorPageRender extends ErrorPageRenderer {
         return (HTML == fmt
                 || CSV == fmt
                 || H.Format.JSON == fmt
+                || H.Format.TXT == fmt
                 || XML == fmt);
     }
 


### PR DESCRIPTION
It looks like forgotten one in ActErrorPageRender.isAcceptGoodForErrorPage() as there is support for TXT just few lines above in ActErrorPageRender.renderTemplate().