### PR TITLE
fix #1391: url.context not show in e404 page

### DIFF
--- a/src/main/java/act/route/Router.java
+++ b/src/main/java/act/route/Router.java
@@ -620,7 +620,7 @@ public class Router extends AppHolderBase<Router> implements TreeNode {
         }
     }
 
-    private String ensureUrlContext(String path) {
+    public String ensureUrlContext(String path) {
         String urlContext = appConfig.urlContext();
         if (null == urlContext || path.startsWith(urlContext)) {
             if ("/".equals(path)) {

--- a/src/main/resources/rythm/error/dev/e404.html
+++ b/src/main/resources/rythm/error/dev/e404.html
@@ -53,10 +53,10 @@
 @def tr(RouteInfo r, String parity) {
   <tr class="route @parity">
     <td class="m">@r.method()</td>
-    <td class="p" title="@r.path()">
-      @{
-        String path = _action.router().ensureUrlContext(r.path());
-      }
+    @{
+      String path = _action.router().ensureUrlContext(r.path());
+    }
+    <td class="p" title="@path">
       @if (r.method() == "GET") {
         <a href="@path">@path</a>
       } else {

--- a/src/main/resources/rythm/error/dev/e404.html
+++ b/src/main/resources/rythm/error/dev/e404.html
@@ -54,10 +54,13 @@
   <tr class="route @parity">
     <td class="m">@r.method()</td>
     <td class="p" title="@r.path()">
+      @{
+        String path = _action.router().ensureUrlContext(r.path());
+      }
       @if (r.method() == "GET") {
-        <a href="@r.path()">@r.path()</a>
+        <a href="@path">@path</a>
       } else {
-        @r.path()
+        @path
       }
     </td>
     <td class="h" title="@r.handler()">@r.compactHandler()</td>


### PR DESCRIPTION
The proposed solution is making method act.route.Router.ensureUrlContext public, then patch the path string in e404 template.