### PR TITLE
fix index error when process string substitution

### DIFF
--- a/src/main/java/act/test/TestSession.java
+++ b/src/main/java/act/test/TestSession.java
@@ -312,8 +312,9 @@ public class TestSession extends LogSupport {
                 buf.append(getVal(key, payload));
             }
             n = s.indexOf("${", a);
+            a++;
             if (n < 0) {
-                buf.append(s.substring(a + 1));
+                buf.append(s.substring(a));
                 return buf.toString();
             }
             z = n;


### PR DESCRIPTION
In test scenario with cached value, for example "/foo1/${v1}/foo2/${v2}", there is index error produce wrong target url "/foo1/1}/foo2/2" (pay attention to the char '}' next to 1). This fix resolve this issue.